### PR TITLE
Prevent updates on a primary key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: install clean
+.PHONY: install clean test
 
 install:
 	npm install
 
 clean: 
 	rm -rf node_modules
+
+test:
+	mocha test

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 0.10.30

--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
     "url": "git://github.com/balderdashy/waterline-sequel.git"
   },
   "dependencies": {
-    "lodash": "~2.4.1"
+    "lodash": "2.4.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+      "should": "8.2.2",
+      "mocha": "2.4.5"
+  },
   "scripts": {},
   "main": "sequel/index",
   "directories": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,67 @@
+var should = require('should');
+
+var Sequel = require('../sequel/index');
+
+var userSchema = {
+  users: {
+    identity: 'users',
+    tableName: 'users',
+    attributes: {
+      id: {
+        primaryKey: true,
+        type: 'text',
+      },
+      email: {
+        type: 'text',
+      },
+      balance: {
+        type: 'integer',
+      },
+    },
+  }
+};
+
+var multiPkSchema = {
+  users: {
+    identity: 'users',
+    tableName: 'users',
+    attributes: {
+      id: {
+        primaryKey: true,
+        type: 'text',
+      },
+      email: {
+        type: 'text',
+        primaryKey: true,
+      },
+      balance: {
+        type: 'integer',
+      },
+    },
+  }
+};
+
+describe('update', function() {
+  it('throws an error if attempting to update a primary key', function() {
+    var sequel = new Sequel(userSchema, {});
+    sequel.update.bind(sequel, 'users', {}, {id: 'foo'}).should.throw(Error, {
+      message: 'Cannot mutate primary key id on users',
+      data: {id: 'foo'},
+    });
+  });
+
+  it('throws an error if attempting to update a schema with multiple primary keys', function() {
+    var sequel = new Sequel(multiPkSchema, {});
+    sequel.update.bind(sequel, 'users', {}, {email: 'foo'}).should.throw(Error, {
+      message: 'Cannot mutate primary key email on users',
+      data: {email: 'foo'},
+    });
+  });
+
+  it('does not throw an error if attempting to update other fields', function() {
+    var sequel = new Sequel(userSchema, {});
+    var val = sequel.update('users', {}, {balance: 3});
+    val.query.trim().should.equal('UPDATE "users" AS "users" SET balance = $1');
+    val.values.should.eql([3]);
+  });
+});


### PR DESCRIPTION
If you attempt to issue an UPDATE where one of the fields being updated is also
the table's primary key, we throw an error instead of returning a query.

Adds a basic test framework as well.
