### PR TITLE
Throw an error if the operator is unknown

### DIFF
--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -691,6 +691,11 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
 
       break;
+
+    default:
+      var err = new Error('Unknown filtering operator: "' + key + "\". Should be 'startsWith', '>', 'contains' or similar");
+      err.operator = key;
+      throw err;
   }
 
   // Bump paramCount

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,4 +64,12 @@ describe('update', function() {
     val.query.trim().should.equal('UPDATE "users" AS "users" SET balance = $1');
     val.values.should.eql([3]);
   });
+
+  it('throws an error if the operator is unknown', function() {
+    var sequel = new Sequel(userSchema, {});
+    sequel.find.bind(sequel, 'users', { balance: { 'in': [ 1, 2 ] } }).should.throw(Error, {
+      message: "Unknown filtering operator: \"in\". Should be 'startsWith', '>', 'contains' or similar",
+      operator: 'in',
+    });
+  });
 });


### PR DESCRIPTION
Previously passing a query with an unknown operator would place the word
"undefined" in the SQL query:

``` javascript
sequel.find('users', { balance: { 'in': [ 1, 2 ] } });
```

``` sql
'SELECT "users"."id", "users"."email", "users"."balance", "users"."pickupCount" FROM "users" AS "users"  "users"."balance" undefined  '
```

(Valid operators are things like 'contains', 'startsWith', 'endsWith', '>'.)

This happens because we define the var `str` to be undefined, never set it, and
then append it to the query string.

Instead, immediately throw an error when an unknown key gets passed to
Waterline, which should help diagnose these problems going forward (instead of
forcing us to parse a Postgres syntax error).

Fixes https://github.com/balderdashy/waterline-sequel/issues/86.
